### PR TITLE
Switch Gradle distribution to ALL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -204,3 +204,8 @@ publishing {
         }
     }
 }
+
+tasks.wrapper {
+    distributionType = Wrapper.DistributionType.ALL
+}
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionSha256Sum=027fdd265d277bae65a0d349b6b8da02135b0b8e14ba891e26281fa877fe37a2
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
To see automatically see source code in Gradle methods.
Along the way upgraded from 5.6 to 5.6.2.